### PR TITLE
Apply Pipe whitelist properly in election-verifier

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -26,7 +26,7 @@ params:
 # global configuration
 config:
   backup_password: '<PASSWORD>'
-  version: '6.0.0-beta.1'
+  version: '6.0.0'
   # global config. Note: currently some other keys are used as global conf
   global_secret_key: '<PASSWORD>'
 
@@ -655,7 +655,7 @@ config:
     # default configuration for calculate results on admin-console
     calculate_results_default: >-
       {
-        "version": "6.0.0-beta.1",
+        "version": "6.0.0",
         "pipes": [
           {
             "type": "tally_pipes.pipes.pdf.configure_pdf",
@@ -691,7 +691,7 @@ config:
         layout: 'simple',
         num_successful_logins_allowed: 0,
         tallyPipesConfig: {
-          version: '6.0.0-beta.1',
+          version: '6.0.0',
           pipes: [
             {
               type: 'tally_pipes.pipes.results.do_tallies',

--- a/config.yml
+++ b/config.yml
@@ -26,7 +26,7 @@ params:
 # global configuration
 config:
   backup_password: '<PASSWORD>'
-  version: 'master'
+  version: '6.0.0-beta.1'
   # global config. Note: currently some other keys are used as global conf
   global_secret_key: '<PASSWORD>'
 
@@ -506,7 +506,7 @@ config:
 
     # Main version shown in the user interface. set to 'false' if you don't
     # want it to be shown.
-    mainVersion: 'master'
+    mainVersion: '6.0.0-beta.1'
 
     # Login session cookies expiration in minutes. set to 'false' to be 
     # unlimited. Does not apply to admin-console cookies (which use the value
@@ -655,7 +655,7 @@ config:
     # default configuration for calculate results on admin-console
     calculate_results_default: >-
       {
-        "version": "master",
+        "version": "6.0.0-beta.1",
         "pipes": [
           {
             "type": "tally_pipes.pipes.pdf.configure_pdf",
@@ -691,7 +691,7 @@ config:
         layout: 'simple',
         num_successful_logins_allowed: 0,
         tallyPipesConfig: {
-          version: 'master',
+          version: '6.0.0-beta.1',
           pipes: [
             {
               type: 'tally_pipes.pipes.results.do_tallies',

--- a/doc/devel/auth1.config.yml
+++ b/doc/devel/auth1.config.yml
@@ -25,7 +25,7 @@ params:
 
 # global configuration
 config:
-  version: 'master'
+  version: '6.0.0-beta.1'
   backup_password: '<PASSWORD>'
 
   # global config. Note: currently some other keys are used as global conf
@@ -647,7 +647,7 @@ config:
     # default configuration for calculate results on admin-console
     calculate_results_default: >-
       {
-        "version": "master",
+        "version": "6.0.0-beta.1",
         "pipes": [
           {
             "type": "tally_pipes.pipes.pdf.configure_pdf",
@@ -683,7 +683,7 @@ config:
         layout: 'simple',
         num_successful_logins_allowed: 0,
         tallyPipesConfig: {
-          version: 'master',
+          version: '6.0.0-beta.1',
           pipes: [
             {
               type: 'tally_pipes.pipes.results.do_tallies',

--- a/doc/devel/auth1.config.yml
+++ b/doc/devel/auth1.config.yml
@@ -25,7 +25,7 @@ params:
 
 # global configuration
 config:
-  version: '6.0.0-beta.1'
+  version: '6.0.0'
   backup_password: '<PASSWORD>'
 
   # global config. Note: currently some other keys are used as global conf
@@ -647,7 +647,7 @@ config:
     # default configuration for calculate results on admin-console
     calculate_results_default: >-
       {
-        "version": "6.0.0-beta.1",
+        "version": "6.0.0",
         "pipes": [
           {
             "type": "tally_pipes.pipes.pdf.configure_pdf",
@@ -683,7 +683,7 @@ config:
         layout: 'simple',
         num_successful_logins_allowed: 0,
         tallyPipesConfig: {
-          version: '6.0.0-beta.1',
+          version: '6.0.0',
           pipes: [
             {
               type: 'tally_pipes.pipes.results.do_tallies',

--- a/doc/devel/auth2.config.yml
+++ b/doc/devel/auth2.config.yml
@@ -25,7 +25,7 @@ params:
 
 # global configuration
 config:
-  version: 'master'
+  version: '6.0.0-beta.1'
   backup_password: '<PASSWORD>'
 
   # global config. Note: currently some other keys are used as global conf
@@ -654,7 +654,7 @@ config:
     # default configuration for calculate results on admin-console
     calculate_results_default: >-
       {
-        "version": "master",
+        "version": "6.0.0-beta.1",
         "pipes": [
           {
             "type": "tally_pipes.pipes.pdf.configure_pdf",
@@ -690,7 +690,7 @@ config:
         layout: 'simple',
         num_successful_logins_allowed: 0,
         tallyPipesConfig: {
-          version: 'master',
+          version: '6.0.0-beta.1',
           pipes: [
             {
               type: 'tally_pipes.pipes.results.do_tallies',

--- a/doc/devel/auth2.config.yml
+++ b/doc/devel/auth2.config.yml
@@ -25,7 +25,7 @@ params:
 
 # global configuration
 config:
-  version: '6.0.0-beta.1'
+  version: '6.0.0'
   backup_password: '<PASSWORD>'
 
   # global config. Note: currently some other keys are used as global conf
@@ -654,7 +654,7 @@ config:
     # default configuration for calculate results on admin-console
     calculate_results_default: >-
       {
-        "version": "6.0.0-beta.1",
+        "version": "6.0.0",
         "pipes": [
           {
             "type": "tally_pipes.pipes.pdf.configure_pdf",
@@ -690,7 +690,7 @@ config:
         layout: 'simple',
         num_successful_logins_allowed: 0,
         tallyPipesConfig: {
-          version: '6.0.0-beta.1',
+          version: '6.0.0',
           pipes: [
             {
               type: 'tally_pipes.pipes.results.do_tallies',

--- a/doc/devel/sequent.config.yml
+++ b/doc/devel/sequent.config.yml
@@ -25,7 +25,7 @@ params:
 
 # global configuration
 config:
-  version: '6.0.0-beta.1'
+  version: '6.0.0'
   backup_password: '<PASSWORD>'
 
   # global config. Note: currently some other keys are used as global conf
@@ -661,7 +661,7 @@ config:
     # default configuration for calculate results on admin-console
     calculate_results_default: >-
       {
-        "version": "6.0.0-beta.1",
+        "version": "6.0.0",
         "pipes": [
           {
             "type": "tally_pipes.pipes.pdf.configure_pdf",
@@ -697,7 +697,7 @@ config:
         layout: 'simple',
         num_successful_logins_allowed: 0,
         tallyPipesConfig: {
-          version: '6.0.0-beta.1',
+          version: '6.0.0',
           pipes: [
             {
               type: 'tally_pipes.pipes.results.do_tallies',

--- a/doc/devel/sequent.config.yml
+++ b/doc/devel/sequent.config.yml
@@ -25,7 +25,7 @@ params:
 
 # global configuration
 config:
-  version: 'master'
+  version: '6.0.0-beta.1'
   backup_password: '<PASSWORD>'
 
   # global config. Note: currently some other keys are used as global conf
@@ -661,7 +661,7 @@ config:
     # default configuration for calculate results on admin-console
     calculate_results_default: >-
       {
-        "version": "master",
+        "version": "6.0.0-beta.1",
         "pipes": [
           {
             "type": "tally_pipes.pipes.pdf.configure_pdf",
@@ -697,7 +697,7 @@ config:
         layout: 'simple',
         num_successful_logins_allowed: 0,
         tallyPipesConfig: {
-          version: 'master',
+          version: '6.0.0-beta.1',
           pipes: [
             {
               type: 'tally_pipes.pipes.results.do_tallies',

--- a/doc/production/config.auth.yml
+++ b/doc/production/config.auth.yml
@@ -25,7 +25,7 @@ params:
 
 # global configuration
 config:
-  version: 'master'
+  version: '6.0.0-beta.1'
   backup_password: '<PASSWORD>'
 
   # global config. Note: currently some other keys are used as global conf
@@ -654,7 +654,7 @@ config:
     # default configuration for calculate results on admin-console
     calculate_results_default: >-
       {
-        "version": "master",
+        "version": "6.0.0-beta.1",
         "pipes": [
           {
             "type": "tally_pipes.pipes.pdf.configure_pdf",
@@ -690,7 +690,7 @@ config:
         layout: 'simple',
         num_successful_logins_allowed: 0,
         tallyPipesConfig: {
-          version: 'master',
+          version: '6.0.0-beta.1',
           pipes: [
             {
               type: 'tally_pipes.pipes.results.do_tallies',

--- a/doc/production/config.auth.yml
+++ b/doc/production/config.auth.yml
@@ -25,7 +25,7 @@ params:
 
 # global configuration
 config:
-  version: '6.0.0-beta.1'
+  version: '6.0.0'
   backup_password: '<PASSWORD>'
 
   # global config. Note: currently some other keys are used as global conf
@@ -654,7 +654,7 @@ config:
     # default configuration for calculate results on admin-console
     calculate_results_default: >-
       {
-        "version": "6.0.0-beta.1",
+        "version": "6.0.0",
         "pipes": [
           {
             "type": "tally_pipes.pipes.pdf.configure_pdf",
@@ -690,7 +690,7 @@ config:
         layout: 'simple',
         num_successful_logins_allowed: 0,
         tallyPipesConfig: {
-          version: '6.0.0-beta.1',
+          version: '6.0.0',
           pipes: [
             {
               type: 'tally_pipes.pipes.results.do_tallies',

--- a/doc/production/config.master.yml
+++ b/doc/production/config.master.yml
@@ -25,7 +25,7 @@ params:
 
 # global configuration
 config:
-  version: 'master'
+  version: '6.0.0-beta.1'
   backup_password: '<PASSWORD>'
 
   # global config. Note: currently some other keys are used as global conf
@@ -654,7 +654,7 @@ config:
     # default configuration for calculate results on admin-console
     calculate_results_default: >-
       {
-        "version": "master",
+        "version": "6.0.0-beta.1",
         "pipes": [
           {
             "type": "tally_pipes.pipes.pdf.configure_pdf",
@@ -690,7 +690,7 @@ config:
         layout: 'simple',
         num_successful_logins_allowed: 0,
         tallyPipesConfig: {
-          version: 'master',
+          version: '6.0.0-beta.1',
           pipes: [
             {
               type: 'tally_pipes.pipes.results.do_tallies',

--- a/doc/production/config.master.yml
+++ b/doc/production/config.master.yml
@@ -25,7 +25,7 @@ params:
 
 # global configuration
 config:
-  version: '6.0.0-beta.1'
+  version: '6.0.0'
   backup_password: '<PASSWORD>'
 
   # global config. Note: currently some other keys are used as global conf
@@ -654,7 +654,7 @@ config:
     # default configuration for calculate results on admin-console
     calculate_results_default: >-
       {
-        "version": "6.0.0-beta.1",
+        "version": "6.0.0",
         "pipes": [
           {
             "type": "tally_pipes.pipes.pdf.configure_pdf",
@@ -690,7 +690,7 @@ config:
         layout: 'simple',
         num_successful_logins_allowed: 0,
         tallyPipesConfig: {
-          version: '6.0.0-beta.1',
+          version: '6.0.0',
           pipes: [
             {
               type: 'tally_pipes.pipes.results.do_tallies',

--- a/election-verifier/repo.yml
+++ b/election-verifier/repo.yml
@@ -67,14 +67,6 @@
     dest: /home/verifier_user/tally-pipes
     force: "{{ repos.results.force }}"
 
-- name: election-verifier, update pipes whitelist
-  become: true
-  become_user: verifier_user
-  replace:
-    dest: /home/verifier_user/tally-pipes/tally-pipes
-    regexp: '(DEFAULT_PIPES_WHITELIST = \[)[^\]]*(\])'
-    replace: '\1\n{% for pipe in config.tally_pipes.pipes_whitelist %}    "{{pipe}}",\n{% endfor %}\2'
-
 - name: election-verifier, fresh start
   become: true
   become_user: verifier_user
@@ -99,6 +91,14 @@
 
     - src: '/home/verifier_user/tally-pipes/tally-pipes'
       dest: '/home/verifier_user/election-verifier/tally-pipes'
+
+- name: election-verifier, update pipes whitelist
+  become: true
+  become_user: verifier_user
+  replace:
+    dest: /home/verifier_user/election-verifier/tally_pipes/main.py
+    regexp: '(DEFAULT_PIPES_WHITELIST = \[)[^\]]*(\])'
+    replace: '\1\n{% for pipe in config.tally_pipes.pipes_whitelist %}    "{{pipe}}",\n{% endfor %}\2'
 
 - name: election-verifier, executable bits
   become: true

--- a/helper-tools/config_prod_env.py
+++ b/helper-tools/config_prod_env.py
@@ -21,9 +21,9 @@ import sys
 import argparse
 import re
 
-INPUT_PROD_VERSION="4.0.0"
-INPUT_PRE_VERSION="master"
-OUTPUT_PROD_VERSION="master"
+INPUT_PROD_VERSION="master"
+INPUT_PRE_VERSION="6.0.0-beta.1"
+OUTPUT_PROD_VERSION="6.0.0-beta.1"
 def store_keyvalue(prod_config, generated_config, keystore, pipe):
   '''
   Updates the keyvalue store

--- a/helper-tools/config_prod_env.py
+++ b/helper-tools/config_prod_env.py
@@ -21,9 +21,9 @@ import sys
 import argparse
 import re
 
-INPUT_PROD_VERSION="master"
-INPUT_PRE_VERSION="6.0.0-beta.1"
-OUTPUT_PROD_VERSION="6.0.0-beta.1"
+INPUT_PROD_VERSION="6.0.0-beta.1"
+INPUT_PRE_VERSION="6.0.0"
+OUTPUT_PROD_VERSION="6.0.0"
 def store_keyvalue(prod_config, generated_config, keystore, pipe):
   '''
   Updates the keyvalue store

--- a/repos.yml
+++ b/repos.yml
@@ -17,53 +17,53 @@
 repos:
     ballot_box:
         repo: https://github.com/sequentech/ballot-box.git
-        version: '6.0.0-beta.1'
+        version: '6.0.0'
         force: yes
     results:
         repo: https://github.com/sequentech/tally-pipes.git
-        version: '6.0.0-beta.1'
+        version: '6.0.0'
         force: yes
     tally:
         repo: https://github.com/sequentech/tally-methods.git
-        version: '6.0.0-beta.1'
+        version: '6.0.0'
         force: yes
     iam:
         repo: https://github.com/sequentech/iam.git
-        version: '6.0.0-beta.1'
+        version: '6.0.0'
         force: yes
     misc_tools:
         repo: https://github.com/sequentech/misc-tools.git
-        version: '6.0.0-beta.1'
+        version: '6.0.0'
         force: yes
     frestq:
         repo: https://github.com/sequentech/frestq
-        version: '6.0.0-beta.1'
+        version: '6.0.0'
         force: yes
     eorchestra:
         repo: https://github.com/sequentech/election-orchestra
-        version: '6.0.0-beta.1'
+        version: '6.0.0'
         force: yes
     mixnet:
         repo: https://github.com/sequentech/mixnet
-        version: '6.0.0-beta.1'
+        version: '6.0.0'
         force: yes
     election_verifier:
         repo: https://github.com/sequentech/election-verifier.git
-        version: '6.0.0-beta.1'
+        version: '6.0.0'
         force: yes
     common_ui:
         repo: https://github.com/sequentech/common-ui.git
-        version: '6.0.0-beta.1'
+        version: '6.0.0'
         force: yes
     admin_console:
         repo: https://github.com/sequentech/admin-console.git
-        version: '6.0.0-beta.1'
+        version: '6.0.0'
         force: yes
     voting_booth:
         repo: https://github.com/sequentech/voting-booth.git
-        version: '6.0.0-beta.1'
+        version: '6.0.0'
         force: yes
     election_portal:
         repo: https://github.com/sequentech/election-portal.git
-        version: '6.0.0-beta.1'
+        version: '6.0.0'
         force: yes

--- a/repos.yml
+++ b/repos.yml
@@ -17,53 +17,53 @@
 repos:
     ballot_box:
         repo: https://github.com/sequentech/ballot-box.git
-        version: 'master'
+        version: '6.0.0-beta.1'
         force: yes
     results:
         repo: https://github.com/sequentech/tally-pipes.git
-        version: 'master'
+        version: '6.0.0-beta.1'
         force: yes
     tally:
         repo: https://github.com/sequentech/tally-methods.git
-        version: 'master'
+        version: '6.0.0-beta.1'
         force: yes
     iam:
         repo: https://github.com/sequentech/iam.git
-        version: 'master'
+        version: '6.0.0-beta.1'
         force: yes
     misc_tools:
         repo: https://github.com/sequentech/misc-tools.git
-        version: 'master'
+        version: '6.0.0-beta.1'
         force: yes
     frestq:
         repo: https://github.com/sequentech/frestq
-        version: 'master'
+        version: '6.0.0-beta.1'
         force: yes
     eorchestra:
         repo: https://github.com/sequentech/election-orchestra
-        version: 'master'
+        version: '6.0.0-beta.1'
         force: yes
     mixnet:
         repo: https://github.com/sequentech/mixnet
-        version: 'master'
+        version: '6.0.0-beta.1'
         force: yes
     election_verifier:
         repo: https://github.com/sequentech/election-verifier.git
-        version: 'master'
+        version: '6.0.0-beta.1'
         force: yes
     common_ui:
         repo: https://github.com/sequentech/common-ui.git
-        version: 'master'
+        version: '6.0.0-beta.1'
         force: yes
     admin_console:
         repo: https://github.com/sequentech/admin-console.git
-        version: 'master'
+        version: '6.0.0-beta.1'
         force: yes
     voting_booth:
         repo: https://github.com/sequentech/voting-booth.git
-        version: 'master'
+        version: '6.0.0-beta.1'
         force: yes
     election_portal:
         repo: https://github.com/sequentech/election-portal.git
-        version: 'master'
+        version: '6.0.0-beta.1'
         force: yes

--- a/sequent-ui/templates/SequentConfig.js
+++ b/sequent-ui/templates/SequentConfig.js
@@ -20,7 +20,7 @@
  * in this same file, which you might want to edit and tune if needed.
  */
 
-var SEQUENT_CONFIG_VERSION = 'master';
+var SEQUENT_CONFIG_VERSION = '6.0.0-beta.1';
 
 var SequentConfigData = {
   // the base url path for ajax requests, for example for sending ballots or

--- a/sequent-ui/templates/SequentConfig.js
+++ b/sequent-ui/templates/SequentConfig.js
@@ -20,7 +20,7 @@
  * in this same file, which you might want to edit and tune if needed.
  */
 
-var SEQUENT_CONFIG_VERSION = '6.0.0-beta.1';
+var SEQUENT_CONFIG_VERSION = '6.0.0';
 
 var SequentConfigData = {
   // the base url path for ajax requests, for example for sending ballots or


### PR DESCRIPTION
The pipe whitelist was not being set correctly in election-verifier, so instead of using the one configured in `config.yml`, the default pipe whitelist remained. 