### PR TITLE
Support HTML format when sending email auth-codes

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1127,6 +1127,11 @@ config:
     # Default: false
     allow_admin_registration: false
 
+    # For admins:
+    # Allow sending custom html in the email messages sent from the admin console.
+    # Allowed values: true|false
+    allow_html_emails: false
+
     # callbacks given to ballot_box instances, for now related to sending
     # the result of uploading tally sheets only. It's a list so that it can
     # upload multiple ballot_box instances

--- a/doc/devel/auth1.config.yml
+++ b/doc/devel/auth1.config.yml
@@ -1108,6 +1108,11 @@ config:
     # Default: false
     allow_admin_registration: false
 
+    # For admins:
+    # Allow sending custom html in the email messages sent from the admin console.
+    # Allowed values: true|false
+    allow_html_emails: false
+
     # Number of seconds after which an authentication token expires.
     auth_token_expiration_seconds: 600
 

--- a/doc/devel/auth2.config.yml
+++ b/doc/devel/auth2.config.yml
@@ -1115,6 +1115,11 @@ config:
     # Default: false
     allow_admin_registration: false
 
+    # For admins:
+    # Allow sending custom html in the email messages sent from the admin console.
+    # Allowed values: true|false
+    allow_html_emails: false
+
     # Number of seconds after which an authentication token expires.
     auth_token_expiration_seconds: 600
 

--- a/doc/devel/sequent.config.yml
+++ b/doc/devel/sequent.config.yml
@@ -1122,6 +1122,11 @@ config:
     # Default: false
     allow_admin_registration: false
 
+    # For admins:
+    # Allow sending custom html in the email messages sent from the admin console.
+    # Allowed values: true|false
+    allow_html_emails: false
+
     # Number of seconds after which an authentication token expires.
     auth_token_expiration_seconds: 600
 

--- a/doc/production/config.auth.yml
+++ b/doc/production/config.auth.yml
@@ -1122,6 +1122,11 @@ config:
     # Default: false
     allow_admin_registration: false
 
+    # For admins:
+    # Allow sending custom html in the email messages sent from the admin console.
+    # Allowed values: true|false
+    allow_html_emails: false
+
     # callbacks given to ballot_box instances, for now related to sending
     # the result of uploading tally sheets only. It's a list so that it can
     # upload multiple ballot_box instances

--- a/doc/production/config.master.yml
+++ b/doc/production/config.master.yml
@@ -1122,6 +1122,11 @@ config:
     # Default: false
     allow_admin_registration: false
 
+    # For admins:
+    # Allow sending custom html in the email messages sent from the admin console.
+    # Allowed values: true|false
+    allow_html_emails: false
+
     # callbacks given to ballot_box instances, for now related to sending
     # the result of uploading tally sheets only. It's a list so that it can
     # upload multiple ballot_box instances

--- a/iam/templates/deploy.py
+++ b/iam/templates/deploy.py
@@ -125,6 +125,12 @@ ALLOW_ADMIN_AUTH_REGISTRATION = {% if config.iam.allow_admin_registration %}True
 # default: true
 ALLOW_DEREGISTER = {% if config.iam.allow_deregister %}True{% else %}False{% endif %}
 
+# For admins:
+# Allow sending custom html in the email messages sent from the admin console.
+# Allowed values: True|False
+# Default: False
+ALLOW_HTML_EMAILS = {% if config.iam.allow_html_emails %}True{% else %}False{% endif %}
+
 # If this option is true, when an user tries to register and the user is
 # already registered, iam will return an error with the 'user_exists'
 # codename. Otherwise, on error, iam will always return the same generic

--- a/iam/templates/test_settings.py
+++ b/iam/templates/test_settings.py
@@ -51,6 +51,8 @@ TIME_ZONE = 'Europe/Madrid'
 
 ALLOW_DEREGISTER = True
 
+ALLOW_HTML_EMAILS = True
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/
 

--- a/sequent-ui/templates/SequentConfig.js
+++ b/sequent-ui/templates/SequentConfig.js
@@ -79,6 +79,11 @@ var SequentConfigData = {
   // Allowed values: true|false
   allowAdminRegistration: {% if config.iam.allow_admin_registration %}true{% else %}false{% endif %},
 
+  // For admins:
+  // Allow sending custom html in the email messages sent from the admin console.
+  // Allowed values: true|false
+  allowHtmlEmails: {% if config.iam.allow_html_emails %}true{% else %}false{% endif %},
+
   // show the documentation links after successfully casting a vote
   // allowed values: true| false
   showDocOnVoteCast: {% if config.sequent_ui.show_doc_on_vote_cast %}true{% else %}false{% endif %},


### PR DESCRIPTION
# Changes

* Add configuration field `allow_html_emails` to enable sending emails with an html body.