### PR TITLE
fix cloudflare flag

### DIFF
--- a/oneserver/templates/cloudflare.conf
+++ b/oneserver/templates/cloudflare.conf
@@ -10,7 +10,8 @@ set_real_ip_from   188.114.96.0/20;
 set_real_ip_from   197.234.240.0/22;
 set_real_ip_from   198.41.128.0/17;
 set_real_ip_from   162.158.0.0/15;
-set_real_ip_from   104.16.0.0/12;
+set_real_ip_from   104.16.0.0/13;
+set_real_ip_from   104.24.0.0/14;
 set_real_ip_from   172.64.0.0/13;
 set_real_ip_from   131.0.72.0/22;
 set_real_ip_from   2400:cb00::/32;
@@ -20,34 +21,6 @@ set_real_ip_from   2405:b500::/32;
 set_real_ip_from   2405:8100::/32;
 set_real_ip_from   2a06:98c0::/29;
 set_real_ip_from   2c0f:f248::/32;
-
-allow 173.245.48.0/20;
-allow 103.21.244.0/22;
-allow 103.22.200.0/22;
-allow 103.31.4.0/22;
-allow 141.101.64.0/18;
-allow 108.162.192.0/18;
-allow 190.93.240.0/20;
-allow 188.114.96.0/20;
-allow 197.234.240.0/22;
-allow 198.41.128.0/17;
-allow 162.158.0.0/15;
-allow 104.16.0.0/12;
-allow 172.64.0.0/13;
-allow 131.0.72.0/22;
-allow 2400:cb00::/32;
-allow 2606:4700::/32;
-allow 2803:f800::/32;
-allow 2405:b500::/32;
-allow 2405:8100::/32;
-allow 2a06:98c0::/29;
-allow 2c0f:f248::/32;
-deny  all;
-
-{% if not config.load_balancing.enabled %}
-allow {{config.load_balancing.loadbalancers_cidr}};
-{% endif %}
-
 
 {% if not config.load_balancing.enabled %}
 real_ip_header     CF-Connecting-IP;


### PR DESCRIPTION
Remove the allows/denys because they don't work well together with set_real_ip_from as explained here: https://superuser.com/questions/960454/how-do-i-use-allow-deny-in-conjunction-with-set-real-ip-from

Allows/denys can still be applied at the firewall level, for example as security policies in AWS EC2.