### PR TITLE
Prevent site translation

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -583,6 +583,9 @@ config:
       - es
       - gl
       - ca
+    
+    # Prevents site translation using the translation=off html attribute
+    prevent_site_translation: false
 
     defaultRoute: /admin/login
 

--- a/doc/devel/auth1.config.yml
+++ b/doc/devel/auth1.config.yml
@@ -571,6 +571,9 @@ config:
       - es
       - gl
       - ca
+    
+    # Prevents site translation using the translation=no html attribute
+    prevent_site_translation: false
 
     defaultRoute: /admin/login
 

--- a/doc/devel/auth2.config.yml
+++ b/doc/devel/auth2.config.yml
@@ -578,6 +578,9 @@ config:
       - es
       - gl
       - ca
+    
+    # Prevents site translation using the translation=no html attribute
+    prevent_site_translation: false
 
     defaultRoute: /admin/login
 

--- a/doc/devel/sequent.config.yml
+++ b/doc/devel/sequent.config.yml
@@ -571,6 +571,9 @@ config:
       - es
       - gl
       - ca
+    
+    # Prevents site translation using the translation=no html attribute
+    prevent_site_translation: false
 
     defaultRoute: /admin/login
 

--- a/doc/production/config.auth.yml
+++ b/doc/production/config.auth.yml
@@ -578,6 +578,9 @@ config:
       - es
       - gl
       - ca
+    
+    # Prevents site translation using the translation=no html attribute
+    prevent_site_translation: false
 
     defaultRoute: /admin/login
 

--- a/doc/production/config.master.yml
+++ b/doc/production/config.master.yml
@@ -578,6 +578,9 @@ config:
       - es
       - gl
       - ca
+    
+    # Prevents site translation using the translation=no html attribute
+    prevent_site_translation: false
 
     defaultRoute: /admin/login
 

--- a/sequent-ui/templates/SequentConfig.js
+++ b/sequent-ui/templates/SequentConfig.js
@@ -52,6 +52,10 @@ var SequentConfigData = {
   // Show 'Success Action' tab in admin sequent_ui
   showSuccessAction: {% if config.sequent_ui.show_success_action %}true{% else %}false{% endif %},
 
+  // Prevents site translation using the translation=on html attribute
+  // allowed values: true | false
+  preventSiteTranslation: {% if config.sequent_ui.prevent_site_translation %}true{% else %}false{% endif %},
+
   // AuthApi base url
   authAPI: "https://{{config.ballot_box.domain}}/iam/api/",
   dnieUrl: "https://{{config.ballot_box.domain}}/iam/api/authmethod/dnie/auth/",


### PR DESCRIPTION
## Problem description

In some cases, the web browser automatically translates the frontend web sites when it shouldn't. EPI has reported this happening in a case in which the whole website is already in english, but the browser detects the german article `die` as an english word and translate it to the english translation of the word `die`. Not good.

## Proposed Solution

Add to `config.yml` a parameter `config.sequent_ui.prevent_site_translation` that is `false` by default, but when enabled it sets the `translate="no"` attribute to the `<html>` element . [`translate`is an official HTML5 attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/translate) that indicates that the content of this element should not be translated.

## Rationale

Adding the `translate="no"` attribute should prevent the browser from translating what it shouldn't. Note that, we are already indicating the language of the content in the HTML element, so it should not be translating from that language. And if the text language is for example "german" and the user wants a translation to "arabic", we would be preventing that from happening. For that reason, this should not be enabled by default. But in any specific deployment, it can be set.
