### PR TITLE
Election results take 30 seconds to publish because of fixed-time caching

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -406,8 +406,8 @@ config:
     ssl_port: 14453
 
     # Numbers of seconds memcached mantains a cached item (an election)
-    # in the cache. By default it's 60 seconds.
-    cache_expiration_seconds: 60
+    # in the cache. By default it's 5 seconds.
+    cache_expiration_seconds: 5
 
     # allow and deny nginx ips specific for this service
     ips:

--- a/oneserver/templates/oneserver.conf
+++ b/oneserver/templates/oneserver.conf
@@ -45,7 +45,7 @@ server {
     # cache config
     proxy_cache_key         "$scheme$host$uri$is_args$args";
     proxy_cache             STATIC;
-    proxy_cache_valid       any 1m;
+    proxy_cache_valid       any {{ config.ballot_box.cache_expiration_seconds }}s;
     proxy_cache_min_uses    3;
     proxy_cache_bypass      $http_authorization;
     proxy_cache_use_stale   error timeout updating http_500 http_502 http_503 http_504;


### PR DESCRIPTION
Fixes https://github.com/sequentech/meta/issues/66

- Problem description

When changing the status of an election, it takes about 30 seconds for it to be updated in the public site of the election. For example, when publishing the results of an election when they are in the election results calculated (but not yet published) stage. The reason is caching, but this should not take so long and should be configurable.

First, there are three different levels of caching:
1. **Cloudflare**: one can configure the Edge TTL cache expiration and other cache rules. This is out of the scope of the software and out of the scope of this bug. We recommend a low Edge TTL, like 5 seconds, which should be enough. Also, to make it simple we recommend using the same TTL for all cache levels.
2. **Nginx**: Right now this is can only be enabled or disabled in the deployment's `config.yml` with the `config.webserver.reverse_proxy_cache` setting and it has a fixed setting of 1 minute.
3. **Memcached**: Elections are cached also in memcached for a default of 60 seconds, configurable with the `config.ballot_box.cache_expiration_seconds` setting in `config.yml`.

- Proposed Solution

1. Change the default `config.ballot_box.cache_expiration_seconds` setting from `60` to `5` seconds.
2. Apply the same TTL set in the `config.ballot_box.cache_expiration_seconds` setting for Nginx caching, so that it is configurable and we do not need another setting to configure for this.